### PR TITLE
Fix Invalid UTF-8 Characters

### DIFF
--- a/lib/sofatutor/search_sniffer/referring_search.rb
+++ b/lib/sofatutor/search_sniffer/referring_search.rb
@@ -45,6 +45,10 @@ module Sofatutor  #:nodoc:
           break unless params && params.has_key?(query_param_name)
 
           @raw_search_terms = [params[query_param_name]].flatten.join(' ')
+
+          # Make sure we have valid UTF-8 before applying the StopWords pattern
+          @raw_search_terms.encode!(Encoding::UTF_8, invalid: :replace)
+
           @search_terms = @raw_search_terms.gsub(StopWords, '').squeeze(' ')
           break
         end

--- a/test/search_sniffer_test.rb
+++ b/test/search_sniffer_test.rb
@@ -42,4 +42,12 @@ class ReferringSearchTest < Test::Unit::TestCase
     assert_equal sniffer.raw_search_terms, nil
     assert_equal sniffer.search_terms, nil
   end
+
+  def test_referrer_with_invalid_utf8
+    referrer = "http://www.google.com/search?q=%FCbungen"
+    sniffer = Sofatutor::SearchSniffer::ReferringSearch.new referrer
+    assert_equal sniffer.engine, :google
+    assert_equal sniffer.raw_search_terms, "�bungen"
+    assert_equal sniffer.search_terms, "�bungen"
+  end
 end


### PR DESCRIPTION
Some referrers produce a "invalid byte sequence in UTF-8" error. This patch makes sure the invalid characters are replaced.